### PR TITLE
Translate Japanese store names and iPhone 17 colors to Chinese

### DIFF
--- a/config/files/products_en_AU.json
+++ b/config/files/products_en_AU.json
@@ -53,23 +53,23 @@
           "multiVariantsDisplayTitle": "Choose a colour:"
         },
         "lavender": {
-          "value": "Lavender",
+          "value": "薰衣草紫色",
           "image": "<em class=\"click-layer\"></em> <div class=\"effect pink \"><img src=\"https://store.storeimages.cdn-apple.com/1/as-images.apple.com/is/iphone-17-finish-lavender-202509?wid=204&amp;hei=204&amp;fmt=jpeg&amp;qlt=90&amp;.v=WGdCRlQ0YVlqbTdXTEkxRnVQb0oxdmprcGpjY2l5RUIzeVFrbmJvUWtqc2RGZkRIOXlYamJZeXJpMktxS05vTmJGcXNRQnFCV0w3WVRjTExvdm1ic1UxMXlrbnZjcG5pSE5vKzQ1Qmlmc201dDgvV3BhU1hoSzFPUEZjam5HQ2g\" alt=\"\" width=\"102\" height=\"102\" class=\"ir\" /></div>"
         },
         "sage": {
-          "value": "Sage",
+          "value": "鼠尾草绿色",
           "image": "<em class=\"click-layer\"></em> <div class=\"effect pink \"><img src=\"https://store.storeimages.cdn-apple.com/1/as-images.apple.com/is/iphone-17-finish-sage-202509?wid=204&amp;hei=204&amp;fmt=jpeg&amp;qlt=90&amp;.v=WGdCRlQ0YVlqbTdXTEkxRnVQb0oxdUNNQ0FSYTZPU3dUUlNOUGtqOGRBMG1FRWhOUGUvNGZuTmxlNGRBWlpkb014MXJScFRZN3Y5OWZsRXVrN1k4cFl2UlpqT3NIQkxHZGtBc1I0MEN5VlE\" alt=\"\" width=\"102\" height=\"102\" class=\"ir\" /></div>"
         },
         "mistblue": {
-          "value": "Mist Blue",
+          "value": "青雾蓝色",
           "image": "<em class=\"click-layer\"></em> <div class=\"effect pink \"><img src=\"https://store.storeimages.cdn-apple.com/1/as-images.apple.com/is/iphone-17-finish-mistblue-202509?wid=204&amp;hei=204&amp;fmt=jpeg&amp;qlt=90&amp;.v=WGdCRlQ0YVlqbTdXTEkxRnVQb0oxdWl5TlJNblQ1TXNxaXhCeUQxS25wUWRGZkRIOXlYamJZeXJpMktxS05vTmJGcXNRQnFCV0w3WVRjTExvdm1ic1hYeHFhQi83RENsMWl1S0xaWXpQbkQrNmVjbmk5c1V4VVk2VEt3TGcxekg\" alt=\"\" width=\"102\" height=\"102\" class=\"ir\" /></div>"
         },
         "white": {
-          "value": "White",
+          "value": "白色",
           "image": "<em class=\"click-layer\"></em> <div class=\"effect pink \"><img src=\"https://store.storeimages.cdn-apple.com/1/as-images.apple.com/is/finish-white-202409?wid=200&amp;hei=200&amp;fmt=jpeg&amp;qlt=90&amp;.v=N1ZuMjN0M0dGZXhnVFNBLzNYR0lpZ2Y3Z2lZOGY1OFRWUWZSdmJmVkRqV0RPS3JEVHZvYnQrZDFkdk56RHlVejNxbTdaQ1pEcEVyUXl2Rjk4ZkNDQkM5RFpwQkY4ejlFVzFKNllWL01aMk0\" alt=\"\" width=\"100\" height=\"100\" class=\"ir\" /></div>"
         },
         "black": {
-          "value": "Black",
+          "value": "黑色",
           "image": "<em class=\"click-layer\"></em> <div class=\"effect black \"><img src=\"https://store.storeimages.cdn-apple.com/1/as-images.apple.com/is/finish-black-202409?wid=200&amp;hei=200&amp;fmt=jpeg&amp;qlt=90&amp;.v=RlpRL3lIcFB1TmI2NEJlaW1pM1BsQWY3Z2lZOGY1OFRWUWZSdmJmVkRqV0RPS3JEVHZvYnQrZDFkdk56RHlVejNxbTdaQ1pEcEVyUXl2Rjk4ZkNDQkQvYVIzWHBIL1JhMitsd2FWTkdFZVU\" alt=\"\" width=\"100\" height=\"100\" class=\"ir\" /></div>"
         },
         "variantOrder": [
@@ -1160,15 +1160,15 @@
           "multiVariantsDisplayTitle": "Choose a colour:"
         },
         "silver": {
-          "value": "Silver",
+          "value": "银色",
           "image": "<em class=\"click-layer\"></em> <div><img src=\"https://store.storeimages.cdn-apple.com/1/as-images.apple.com/is/iphone-17-pro-finish-silver-202509?wid=204&amp;hei=204&amp;fmt=jpeg&amp;qlt=90&amp;.v=NUNzdzNKR0FJbmhKWm5YamRHb05tZkhRZEJOK1JCN0VZN2YvSUFuZTJJUnhweG1tRFR3b1hGVkpTR1M2VGdUZ1BXczhpOGc4aE52a3A4NHJCbVZoRC9KNEo4TzZtQTJKc0ZQNkdiN2VMQ1RZYjhJWFYvelFMWGRIZ09ucFU2SXQ\" alt=\"\" width=\"102\" height=\"102\" class=\"ir\" /></div>"
         },
         "cosmicorange": {
-          "value": "Cosmic Orange",
+          "value": "星宇橙色",
           "image": "<em class=\"click-layer\"></em> <div><img src=\"https://store.storeimages.cdn-apple.com/1/as-images.apple.com/is/iphone-17-pro-finish-cosmicorange-202509?wid=204&amp;hei=204&amp;fmt=jpeg&amp;qlt=90&amp;.v=NUNzdzNKR0FJbmhKWm5YamRHb05tY08zQkx1R090aUtZdHVuR2NMRWdhblpiYnpYR0pydXZYOER5WlBiWVJFUGU0OVhiRStjSHVhTFVibEFReFgzOVQ2K3c3eDN1QlVKV09nQzhyNmV5TTE3bDJUNWRlam9zYktmTmVEVUdtbm0\" alt=\"\" width=\"102\" height=\"102\" class=\"ir\" /></div>"
         },
         "deepblue": {
-          "value": "Deep Blue",
+          "value": "深蓝色",
           "image": "<em class=\"click-layer\"></em> <div><img src=\"https://store.storeimages.cdn-apple.com/1/as-images.apple.com/is/iphone-17-pro-finish-deepblue-202509?wid=204&amp;hei=204&amp;fmt=jpeg&amp;qlt=90&amp;.v=NUNzdzNKR0FJbmhKWm5YamRHb05tWUUveVZtb1RlSStSVytMY1drNG1TZ1FwRm1CeVVzcGdYV2czTDhRMzB2L2xIdGZMeXlzRHpBNW9PZUxLVVpMTjl1ekV6UFFwN2NTekgwWkM5SWhpNnA4cVNzUmJkT2hENmJpMlJma1cvUXU\" alt=\"\" width=\"102\" height=\"102\" class=\"ir\" /></div>"
         },
         "variantOrder": [

--- a/config/files/products_en_MY.json
+++ b/config/files/products_en_MY.json
@@ -53,23 +53,23 @@
           "multiVariantsDisplayTitle": "Choose a colour:"
         },
         "lavender": {
-          "value": "Lavender",
+          "value": "薰衣草紫色",
           "image": "<em class=\"click-layer\"></em> <div class=\"effect pink \"><img src=\"https://store.storeimages.cdn-apple.com/1/as-images.apple.com/is/iphone-17-finish-lavender-202509?wid=204&amp;hei=204&amp;fmt=jpeg&amp;qlt=90&amp;.v=WGdCRlQ0YVlqbTdXTEkxRnVQb0oxdmprcGpjY2l5RUIzeVFrbmJvUWtqc2RGZkRIOXlYamJZeXJpMktxS05vTmJGcXNRQnFCV0w3WVRjTExvdm1ic1UxMXlrbnZjcG5pSE5vKzQ1Qmlmc201dDgvV3BhU1hoSzFPUEZjam5HQ2g\" alt=\"\" width=\"102\" height=\"102\" class=\"ir\" /></div>"
         },
         "sage": {
-          "value": "Sage",
+          "value": "鼠尾草绿色",
           "image": "<em class=\"click-layer\"></em> <div class=\"effect pink \"><img src=\"https://store.storeimages.cdn-apple.com/1/as-images.apple.com/is/iphone-17-finish-sage-202509?wid=204&amp;hei=204&amp;fmt=jpeg&amp;qlt=90&amp;.v=WGdCRlQ0YVlqbTdXTEkxRnVQb0oxdUNNQ0FSYTZPU3dUUlNOUGtqOGRBMG1FRWhOUGUvNGZuTmxlNGRBWlpkb014MXJScFRZN3Y5OWZsRXVrN1k4cFl2UlpqT3NIQkxHZGtBc1I0MEN5VlE\" alt=\"\" width=\"102\" height=\"102\" class=\"ir\" /></div>"
         },
         "mistblue": {
-          "value": "Mist Blue",
+          "value": "青雾蓝色",
           "image": "<em class=\"click-layer\"></em> <div class=\"effect pink \"><img src=\"https://store.storeimages.cdn-apple.com/1/as-images.apple.com/is/iphone-17-finish-mistblue-202509?wid=204&amp;hei=204&amp;fmt=jpeg&amp;qlt=90&amp;.v=WGdCRlQ0YVlqbTdXTEkxRnVQb0oxdWl5TlJNblQ1TXNxaXhCeUQxS25wUWRGZkRIOXlYamJZeXJpMktxS05vTmJGcXNRQnFCV0w3WVRjTExvdm1ic1hYeHFhQi83RENsMWl1S0xaWXpQbkQrNmVjbmk5c1V4VVk2VEt3TGcxekg\" alt=\"\" width=\"102\" height=\"102\" class=\"ir\" /></div>"
         },
         "white": {
-          "value": "White",
+          "value": "白色",
           "image": "<em class=\"click-layer\"></em> <div class=\"effect pink \"><img src=\"https://store.storeimages.cdn-apple.com/1/as-images.apple.com/is/finish-white-202409?wid=200&amp;hei=200&amp;fmt=jpeg&amp;qlt=90&amp;.v=N1ZuMjN0M0dGZXhnVFNBLzNYR0lpZ2Y3Z2lZOGY1OFRWUWZSdmJmVkRqV0RPS3JEVHZvYnQrZDFkdk56RHlVejNxbTdaQ1pEcEVyUXl2Rjk4ZkNDQkM5RFpwQkY4ejlFVzFKNllWL01aMk0\" alt=\"\" width=\"100\" height=\"100\" class=\"ir\" /></div>"
         },
         "black": {
-          "value": "Black",
+          "value": "黑色",
           "image": "<em class=\"click-layer\"></em> <div class=\"effect black \"><img src=\"https://store.storeimages.cdn-apple.com/1/as-images.apple.com/is/finish-black-202409?wid=200&amp;hei=200&amp;fmt=jpeg&amp;qlt=90&amp;.v=RlpRL3lIcFB1TmI2NEJlaW1pM1BsQWY3Z2lZOGY1OFRWUWZSdmJmVkRqV0RPS3JEVHZvYnQrZDFkdk56RHlVejNxbTdaQ1pEcEVyUXl2Rjk4ZkNDQkQvYVIzWHBIL1JhMitsd2FWTkdFZVU\" alt=\"\" width=\"100\" height=\"100\" class=\"ir\" /></div>"
         },
         "variantOrder": [
@@ -1342,15 +1342,15 @@
           "multiVariantsDisplayTitle": "Choose a colour:"
         },
         "silver": {
-          "value": "Silver",
+          "value": "银色",
           "image": "<em class=\"click-layer\"></em> <div><img src=\"https://store.storeimages.cdn-apple.com/1/as-images.apple.com/is/iphone-17-pro-finish-silver-202509?wid=204&amp;hei=204&amp;fmt=jpeg&amp;qlt=90&amp;.v=NUNzdzNKR0FJbmhKWm5YamRHb05tZkhRZEJOK1JCN0VZN2YvSUFuZTJJUnhweG1tRFR3b1hGVkpTR1M2VGdUZ1BXczhpOGc4aE52a3A4NHJCbVZoRC9KNEo4TzZtQTJKc0ZQNkdiN2VMQ1RZYjhJWFYvelFMWGRIZ09ucFU2SXQ\" alt=\"\" width=\"102\" height=\"102\" class=\"ir\" /></div>"
         },
         "cosmicorange": {
-          "value": "Cosmic Orange",
+          "value": "星宇橙色",
           "image": "<em class=\"click-layer\"></em> <div><img src=\"https://store.storeimages.cdn-apple.com/1/as-images.apple.com/is/iphone-17-pro-finish-cosmicorange-202509?wid=204&amp;hei=204&amp;fmt=jpeg&amp;qlt=90&amp;.v=NUNzdzNKR0FJbmhKWm5YamRHb05tY08zQkx1R090aUtZdHVuR2NMRWdhblpiYnpYR0pydXZYOER5WlBiWVJFUGU0OVhiRStjSHVhTFVibEFReFgzOVQ2K3c3eDN1QlVKV09nQzhyNmV5TTE3bDJUNWRlam9zYktmTmVEVUdtbm0\" alt=\"\" width=\"102\" height=\"102\" class=\"ir\" /></div>"
         },
         "deepblue": {
-          "value": "Deep Blue",
+          "value": "深蓝色",
           "image": "<em class=\"click-layer\"></em> <div><img src=\"https://store.storeimages.cdn-apple.com/1/as-images.apple.com/is/iphone-17-pro-finish-deepblue-202509?wid=204&amp;hei=204&amp;fmt=jpeg&amp;qlt=90&amp;.v=NUNzdzNKR0FJbmhKWm5YamRHb05tWUUveVZtb1RlSStSVytMY1drNG1TZ1FwRm1CeVVzcGdYV2czTDhRMzB2L2xIdGZMeXlzRHpBNW9PZUxLVVpMTjl1ekV6UFFwN2NTekgwWkM5SWhpNnA4cVNzUmJkT2hENmJpMlJma1cvUXU\" alt=\"\" width=\"102\" height=\"102\" class=\"ir\" /></div>"
         },
         "variantOrder": [

--- a/config/files/products_en_SG.json
+++ b/config/files/products_en_SG.json
@@ -53,23 +53,23 @@
           "multiVariantsDisplayTitle": "Choose a colour:"
         },
         "lavender": {
-          "value": "Lavender",
+          "value": "薰衣草紫色",
           "image": "<em class=\"click-layer\"></em> <div class=\"effect pink \"><img src=\"https://store.storeimages.cdn-apple.com/1/as-images.apple.com/is/iphone-17-finish-lavender-202509?wid=204&amp;hei=204&amp;fmt=jpeg&amp;qlt=90&amp;.v=WGdCRlQ0YVlqbTdXTEkxRnVQb0oxdmprcGpjY2l5RUIzeVFrbmJvUWtqc2RGZkRIOXlYamJZeXJpMktxS05vTmJGcXNRQnFCV0w3WVRjTExvdm1ic1UxMXlrbnZjcG5pSE5vKzQ1Qmlmc201dDgvV3BhU1hoSzFPUEZjam5HQ2g\" alt=\"\" width=\"102\" height=\"102\" class=\"ir\" /></div>"
         },
         "sage": {
-          "value": "Sage",
+          "value": "鼠尾草绿色",
           "image": "<em class=\"click-layer\"></em> <div class=\"effect pink \"><img src=\"https://store.storeimages.cdn-apple.com/1/as-images.apple.com/is/iphone-17-finish-sage-202509?wid=204&amp;hei=204&amp;fmt=jpeg&amp;qlt=90&amp;.v=WGdCRlQ0YVlqbTdXTEkxRnVQb0oxdUNNQ0FSYTZPU3dUUlNOUGtqOGRBMG1FRWhOUGUvNGZuTmxlNGRBWlpkb014MXJScFRZN3Y5OWZsRXVrN1k4cFl2UlpqT3NIQkxHZGtBc1I0MEN5VlE\" alt=\"\" width=\"102\" height=\"102\" class=\"ir\" /></div>"
         },
         "mistblue": {
-          "value": "Mist Blue",
+          "value": "青雾蓝色",
           "image": "<em class=\"click-layer\"></em> <div class=\"effect pink \"><img src=\"https://store.storeimages.cdn-apple.com/1/as-images.apple.com/is/iphone-17-finish-mistblue-202509?wid=204&amp;hei=204&amp;fmt=jpeg&amp;qlt=90&amp;.v=WGdCRlQ0YVlqbTdXTEkxRnVQb0oxdWl5TlJNblQ1TXNxaXhCeUQxS25wUWRGZkRIOXlYamJZeXJpMktxS05vTmJGcXNRQnFCV0w3WVRjTExvdm1ic1hYeHFhQi83RENsMWl1S0xaWXpQbkQrNmVjbmk5c1V4VVk2VEt3TGcxekg\" alt=\"\" width=\"102\" height=\"102\" class=\"ir\" /></div>"
         },
         "white": {
-          "value": "White",
+          "value": "白色",
           "image": "<em class=\"click-layer\"></em> <div class=\"effect pink \"><img src=\"https://store.storeimages.cdn-apple.com/1/as-images.apple.com/is/finish-white-202409?wid=200&amp;hei=200&amp;fmt=jpeg&amp;qlt=90&amp;.v=N1ZuMjN0M0dGZXhnVFNBLzNYR0lpZ2Y3Z2lZOGY1OFRWUWZSdmJmVkRqV0RPS3JEVHZvYnQrZDFkdk56RHlVejNxbTdaQ1pEcEVyUXl2Rjk4ZkNDQkM5RFpwQkY4ejlFVzFKNllWL01aMk0\" alt=\"\" width=\"100\" height=\"100\" class=\"ir\" /></div>"
         },
         "black": {
-          "value": "Black",
+          "value": "黑色",
           "image": "<em class=\"click-layer\"></em> <div class=\"effect black \"><img src=\"https://store.storeimages.cdn-apple.com/1/as-images.apple.com/is/finish-black-202409?wid=200&amp;hei=200&amp;fmt=jpeg&amp;qlt=90&amp;.v=RlpRL3lIcFB1TmI2NEJlaW1pM1BsQWY3Z2lZOGY1OFRWUWZSdmJmVkRqV0RPS3JEVHZvYnQrZDFkdk56RHlVejNxbTdaQ1pEcEVyUXl2Rjk4ZkNDQkQvYVIzWHBIL1JhMitsd2FWTkdFZVU\" alt=\"\" width=\"100\" height=\"100\" class=\"ir\" /></div>"
         },
         "variantOrder": [
@@ -1160,15 +1160,15 @@
           "multiVariantsDisplayTitle": "Choose a colour:"
         },
         "silver": {
-          "value": "Silver",
+          "value": "银色",
           "image": "<em class=\"click-layer\"></em> <div><img src=\"https://store.storeimages.cdn-apple.com/1/as-images.apple.com/is/iphone-17-pro-finish-silver-202509?wid=204&amp;hei=204&amp;fmt=jpeg&amp;qlt=90&amp;.v=NUNzdzNKR0FJbmhKWm5YamRHb05tZkhRZEJOK1JCN0VZN2YvSUFuZTJJUnhweG1tRFR3b1hGVkpTR1M2VGdUZ1BXczhpOGc4aE52a3A4NHJCbVZoRC9KNEo4TzZtQTJKc0ZQNkdiN2VMQ1RZYjhJWFYvelFMWGRIZ09ucFU2SXQ\" alt=\"\" width=\"102\" height=\"102\" class=\"ir\" /></div>"
         },
         "cosmicorange": {
-          "value": "Cosmic Orange",
+          "value": "星宇橙色",
           "image": "<em class=\"click-layer\"></em> <div><img src=\"https://store.storeimages.cdn-apple.com/1/as-images.apple.com/is/iphone-17-pro-finish-cosmicorange-202509?wid=204&amp;hei=204&amp;fmt=jpeg&amp;qlt=90&amp;.v=NUNzdzNKR0FJbmhKWm5YamRHb05tY08zQkx1R090aUtZdHVuR2NMRWdhblpiYnpYR0pydXZYOER5WlBiWVJFUGU0OVhiRStjSHVhTFVibEFReFgzOVQ2K3c3eDN1QlVKV09nQzhyNmV5TTE3bDJUNWRlam9zYktmTmVEVUdtbm0\" alt=\"\" width=\"102\" height=\"102\" class=\"ir\" /></div>"
         },
         "deepblue": {
-          "value": "Deep Blue",
+          "value": "深蓝色",
           "image": "<em class=\"click-layer\"></em> <div><img src=\"https://store.storeimages.cdn-apple.com/1/as-images.apple.com/is/iphone-17-pro-finish-deepblue-202509?wid=204&amp;hei=204&amp;fmt=jpeg&amp;qlt=90&amp;.v=NUNzdzNKR0FJbmhKWm5YamRHb05tWUUveVZtb1RlSStSVytMY1drNG1TZ1FwRm1CeVVzcGdYV2czTDhRMzB2L2xIdGZMeXlzRHpBNW9PZUxLVVpMTjl1ekV6UFFwN2NTekgwWkM5SWhpNnA4cVNzUmJkT2hENmJpMlJma1cvUXU\" alt=\"\" width=\"102\" height=\"102\" class=\"ir\" /></div>"
         },
         "variantOrder": [

--- a/config/files/products_ja_JP.json
+++ b/config/files/products_ja_JP.json
@@ -75,23 +75,23 @@
           "multiVariantsDisplayTitle": "色を選ぶ："
         },
         "lavender": {
-          "value": "ラベンダー",
+          "value": "薰衣草紫色",
           "image": "<em class=\"click-layer\"></em> <div class=\"effect pink \"><img src=\"https://store.storeimages.cdn-apple.com/1/as-images.apple.com/is/iphone-17-finish-lavender-202509?wid=204&amp;hei=204&amp;fmt=jpeg&amp;qlt=90&amp;.v=WGdCRlQ0YVlqbTdXTEkxRnVQb0oxdmprcGpjY2l5RUIzeVFrbmJvUWtqc2RGZkRIOXlYamJZeXJpMktxS05vTmJGcXNRQnFCV0w3WVRjTExvdm1ic1UxMXlrbnZjcG5pSE5vKzQ1Qmlmc201dDgvV3BhU1hoSzFPUEZjam5HQ2g\" alt=\"\" width=\"102\" height=\"102\" class=\"ir\" /></div>"
         },
         "sage": {
-          "value": "セージ",
+          "value": "鼠尾草绿色",
           "image": "<em class=\"click-layer\"></em> <div class=\"effect pink \"><img src=\"https://store.storeimages.cdn-apple.com/1/as-images.apple.com/is/iphone-17-finish-sage-202509?wid=204&amp;hei=204&amp;fmt=jpeg&amp;qlt=90&amp;.v=WGdCRlQ0YVlqbTdXTEkxRnVQb0oxdUNNQ0FSYTZPU3dUUlNOUGtqOGRBMG1FRWhOUGUvNGZuTmxlNGRBWlpkb014MXJScFRZN3Y5OWZsRXVrN1k4cFl2UlpqT3NIQkxHZGtBc1I0MEN5VlE\" alt=\"\" width=\"102\" height=\"102\" class=\"ir\" /></div>"
         },
         "mistblue": {
-          "value": "ミストブルー",
+          "value": "青雾蓝色",
           "image": "<em class=\"click-layer\"></em> <div class=\"effect pink \"><img src=\"https://store.storeimages.cdn-apple.com/1/as-images.apple.com/is/iphone-17-finish-mistblue-202509?wid=204&amp;hei=204&amp;fmt=jpeg&amp;qlt=90&amp;.v=WGdCRlQ0YVlqbTdXTEkxRnVQb0oxdWl5TlJNblQ1TXNxaXhCeUQxS25wUWRGZkRIOXlYamJZeXJpMktxS05vTmJGcXNRQnFCV0w3WVRjTExvdm1ic1hYeHFhQi83RENsMWl1S0xaWXpQbkQrNmVjbmk5c1V4VVk2VEt3TGcxekg\" alt=\"\" width=\"102\" height=\"102\" class=\"ir\" /></div>"
         },
         "white": {
-          "value": "ホワイト",
+          "value": "白色",
           "image": "<em class=\"click-layer\"></em> <div class=\"effect pink \"><img src=\"https://store.storeimages.cdn-apple.com/1/as-images.apple.com/is/finish-white-202409?wid=200&amp;hei=200&amp;fmt=jpeg&amp;qlt=90&amp;.v=N1ZuMjN0M0dGZXhnVFNBLzNYR0lpZ2Y3Z2lZOGY1OFRWUWZSdmJmVkRqV0RPS3JEVHZvYnQrZDFkdk56RHlVejNxbTdaQ1pEcEVyUXl2Rjk4ZkNDQkM5RFpwQkY4ejlFVzFKNllWL01aMk0\" alt=\"\" width=\"100\" height=\"100\" class=\"ir\" /></div>"
         },
         "black": {
-          "value": "ブラック",
+          "value": "黑色",
           "image": "<em class=\"click-layer\"></em> <div class=\"effect black \"><img src=\"https://store.storeimages.cdn-apple.com/1/as-images.apple.com/is/finish-black-202409?wid=200&amp;hei=200&amp;fmt=jpeg&amp;qlt=90&amp;.v=RlpRL3lIcFB1TmI2NEJlaW1pM1BsQWY3Z2lZOGY1OFRWUWZSdmJmVkRqV0RPS3JEVHZvYnQrZDFkdk56RHlVejNxbTdaQ1pEcEVyUXl2Rjk4ZkNDQkQvYVIzWHBIL1JhMitsd2FWTkdFZVU\" alt=\"\" width=\"100\" height=\"100\" class=\"ir\" /></div>"
         },
         "variantOrder": [
@@ -2292,15 +2292,15 @@
           "multiVariantsDisplayTitle": "色を選ぶ："
         },
         "silver": {
-          "value": "シルバー",
+          "value": "银色",
           "image": "<em class=\"click-layer\"></em> <div><img src=\"https://store.storeimages.cdn-apple.com/1/as-images.apple.com/is/iphone-17-pro-finish-silver-202509?wid=204&amp;hei=204&amp;fmt=jpeg&amp;qlt=90&amp;.v=NUNzdzNKR0FJbmhKWm5YamRHb05tZkhRZEJOK1JCN0VZN2YvSUFuZTJJUnhweG1tRFR3b1hGVkpTR1M2VGdUZ1BXczhpOGc4aE52a3A4NHJCbVZoRC9KNEo4TzZtQTJKc0ZQNkdiN2VMQ1RZYjhJWFYvelFMWGRIZ09ucFU2SXQ\" alt=\"\" width=\"102\" height=\"102\" class=\"ir\" /></div>"
         },
         "cosmicorange": {
-          "value": "コズミックオレンジ",
+          "value": "星宇橙色",
           "image": "<em class=\"click-layer\"></em> <div><img src=\"https://store.storeimages.cdn-apple.com/1/as-images.apple.com/is/iphone-17-pro-finish-cosmicorange-202509?wid=204&amp;hei=204&amp;fmt=jpeg&amp;qlt=90&amp;.v=NUNzdzNKR0FJbmhKWm5YamRHb05tY08zQkx1R090aUtZdHVuR2NMRWdhblpiYnpYR0pydXZYOER5WlBiWVJFUGU0OVhiRStjSHVhTFVibEFReFgzOVQ2K3c3eDN1QlVKV09nQzhyNmV5TTE3bDJUNWRlam9zYktmTmVEVUdtbm0\" alt=\"\" width=\"102\" height=\"102\" class=\"ir\" /></div>"
         },
         "deepblue": {
-          "value": "ディープブルー",
+          "value": "深蓝色",
           "image": "<em class=\"click-layer\"></em> <div><img src=\"https://store.storeimages.cdn-apple.com/1/as-images.apple.com/is/iphone-17-pro-finish-deepblue-202509?wid=204&amp;hei=204&amp;fmt=jpeg&amp;qlt=90&amp;.v=NUNzdzNKR0FJbmhKWm5YamRHb05tWUUveVZtb1RlSStSVytMY1drNG1TZ1FwRm1CeVVzcGdYV2czTDhRMzB2L2xIdGZMeXlzRHpBNW9PZUxLVVpMTjl1ekV6UFFwN2NTekgwWkM5SWhpNnA4cVNzUmJkT2hENmJpMlJma1cvUXU\" alt=\"\" width=\"102\" height=\"102\" class=\"ir\" /></div>"
         },
         "variantOrder": [

--- a/config/files/stores.json
+++ b/config/files/stores.json
@@ -2149,7 +2149,7 @@
         "store": [
           {
             "id": "R718",
-            "name": "Marunouchi",
+            "name": "丸之内",
             "slug": "marunouchi",
             "telephone": "(03) 4213-0500",
             "address": {
@@ -2165,7 +2165,7 @@
           },
           {
             "id": "R119",
-            "name": "Shibuya",
+            "name": "涩谷",
             "slug": "shibuya",
             "telephone": "(03) 6670-1800",
             "address": {
@@ -2181,7 +2181,7 @@
           },
           {
             "id": "R224",
-            "name": "Omotesando",
+            "name": "表参道",
             "slug": "omotesando",
             "telephone": "(03) 6757-4400",
             "address": {
@@ -2197,7 +2197,7 @@
           },
           {
             "id": "R128",
-            "name": "Shinjuku",
+            "name": "新宿",
             "slug": "shinjuku",
             "telephone": "(03) 5656-1800",
             "address": {
@@ -2213,7 +2213,7 @@
           },
           {
             "id": "R079",
-            "name": "Ginza",
+            "name": "银座",
             "slug": "ginza",
             "telephone": "(03) 4345-3600",
             "address": {
@@ -2235,7 +2235,7 @@
         "store": [
           {
             "id": "R005",
-            "name": "Nagoya Sakae",
+            "name": "名古屋荣",
             "slug": "nagoyasakae",
             "telephone": "(052) 238-2400",
             "address": {
@@ -2257,7 +2257,7 @@
         "store": [
           {
             "id": "R710",
-            "name": "Kawasaki",
+            "name": "川崎",
             "slug": "kawasaki",
             "telephone": "(044) 577-5100",
             "address": {
@@ -2279,7 +2279,7 @@
         "store": [
           {
             "id": "R711",
-            "name": "Kyoto",
+            "name": "京都",
             "slug": "kyoto",
             "telephone": "(075) 757-8700",
             "address": {
@@ -2301,7 +2301,7 @@
         "store": [
           {
             "id": "R048",
-            "name": "Fukuoka",
+            "name": "福冈",
             "slug": "fukuoka",
             "telephone": "(092) 778-0200",
             "address": {
@@ -2323,7 +2323,7 @@
         "store": [
           {
             "id": "R768",
-            "name": "Umeda",
+            "name": "梅田",
             "slug": "umeda",
             "telephone": "(06) 7526-6200",
             "address": {
@@ -2339,7 +2339,7 @@
           },
           {
             "id": "R091",
-            "name": "Shinsaibashi",
+            "name": "心斋桥",
             "slug": "shinsaibashi",
             "telephone": "(06) 4965-2900",
             "address": {
@@ -2365,7 +2365,7 @@
         "store": [
           {
             "id": "R718",
-            "name": "Marunouchi",
+            "name": "丸之内",
             "slug": "marunouchi",
             "telephone": "(03) 4213-0500",
             "address": {
@@ -2381,7 +2381,7 @@
           },
           {
             "id": "R119",
-            "name": "Shibuya",
+            "name": "涩谷",
             "slug": "shibuya",
             "telephone": "(03) 6670-1800",
             "address": {
@@ -2397,7 +2397,7 @@
           },
           {
             "id": "R224",
-            "name": "Omotesando",
+            "name": "表参道",
             "slug": "omotesando",
             "telephone": "(03) 6757-4400",
             "address": {
@@ -2413,7 +2413,7 @@
           },
           {
             "id": "R128",
-            "name": "Shinjuku",
+            "name": "新宿",
             "slug": "shinjuku",
             "telephone": "(03) 5656-1800",
             "address": {
@@ -2429,7 +2429,7 @@
           },
           {
             "id": "R079",
-            "name": "Ginza",
+            "name": "银座",
             "slug": "ginza",
             "telephone": "(03) 4345-3600",
             "address": {
@@ -2451,7 +2451,7 @@
         "store": [
           {
             "id": "R005",
-            "name": "Nagoya Sakae",
+            "name": "名古屋荣",
             "slug": "nagoyasakae",
             "telephone": "(052) 238-2400",
             "address": {
@@ -2473,7 +2473,7 @@
         "store": [
           {
             "id": "R710",
-            "name": "Kawasaki",
+            "name": "川崎",
             "slug": "kawasaki",
             "telephone": "(044) 577-5100",
             "address": {
@@ -2495,7 +2495,7 @@
         "store": [
           {
             "id": "R711",
-            "name": "Kyoto",
+            "name": "京都",
             "slug": "kyoto",
             "telephone": "(075) 757-8700",
             "address": {
@@ -2517,7 +2517,7 @@
         "store": [
           {
             "id": "R048",
-            "name": "Fukuoka",
+            "name": "福冈",
             "slug": "fukuoka",
             "telephone": "(092) 778-0200",
             "address": {
@@ -2539,7 +2539,7 @@
         "store": [
           {
             "id": "R768",
-            "name": "Umeda",
+            "name": "梅田",
             "slug": "umeda",
             "telephone": "(06) 7526-6200",
             "address": {
@@ -2555,7 +2555,7 @@
           },
           {
             "id": "R091",
-            "name": "Shinsaibashi",
+            "name": "心斋桥",
             "slug": "shinsaibashi",
             "telephone": "(06) 4965-2900",
             "address": {


### PR DESCRIPTION
## Summary
- translate Japan store names in the store configuration to their Chinese names so the Japan region display matches the requested locale
- localize the iPhone 17 colour labels across available product configuration files to Chinese values

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df8818c02c83318d9173a2f7f9e950