### PR TITLE
Translate Japanese store regions and adjust macOS packaging

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -43,18 +43,27 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - name: Install fyne-cross
+      - name: Install Fyne tooling
         run: |
           go install fyne.io/fyne/v2/cmd/fyne@latest
-          go install github.com/fyne-io/fyne-cross@latest
           echo "${HOME}/go/bin" >> $GITHUB_PATH
       - name: Build macOS packages
         run: |
-          fyne-cross darwin -arch=amd64,arm64 -app-id=apple.store.helper -name="Apple Store Helper"
+          mkdir -p dist/macos
+          for arch in amd64 arm64; do
+            export GOOS=darwin
+            export GOARCH=${arch}
+            export CGO_ENABLED=1
+            rm -rf "Apple Store Helper.app"
+            fyne package -os darwin -appID apple.store.helper -name "Apple Store Helper"
+            OUT_DIR="dist/macos/darwin-${arch}"
+            mkdir -p "${OUT_DIR}"
+            mv "Apple Store Helper.app" "${OUT_DIR}/"
+          done
       - name: Fix macOS app signatures
         run: |
           for arch in arm64 amd64; do
-            APP_DIR="fyne-cross/dist/darwin-${arch}/Apple Store Helper.app"
+            APP_DIR="dist/macos/darwin-${arch}/Apple Store Helper.app"
             if [ -d "$APP_DIR" ]; then
               xattr -cr "$APP_DIR"
               codesign --force --deep --sign - "$APP_DIR"
@@ -65,4 +74,4 @@ jobs:
         with:
           name: macos-packages
           path: |
-            fyne-cross/dist/darwin-*/
+            dist/macos/

--- a/config/files/stores.json
+++ b/config/files/stores.json
@@ -2145,7 +2145,7 @@
     "state": [
       {
         "__typename": "RgdsState",
-        "name": "Tokyo",
+        "name": "东京都",
         "store": [
           {
             "id": "R718",
@@ -2158,7 +2158,7 @@
               "city": "Chiyoda-ku",
               "postalCode": "100-0005",
               "__typename": "PostalAddress",
-              "stateName": "Tokyo",
+              "stateName": "东京都",
               "stateCode": null
             },
             "__typename": "RgdsStore"
@@ -2174,7 +2174,7 @@
               "city": "Shibuya-ku",
               "postalCode": "150-0041",
               "__typename": "PostalAddress",
-              "stateName": "Tokyo",
+              "stateName": "东京都",
               "stateCode": null
             },
             "__typename": "RgdsStore"
@@ -2190,7 +2190,7 @@
               "city": "Shibuya-ku",
               "postalCode": "150-0001",
               "__typename": "PostalAddress",
-              "stateName": "Tokyo",
+              "stateName": "东京都",
               "stateCode": null
             },
             "__typename": "RgdsStore"
@@ -2206,7 +2206,7 @@
               "city": "Shinjuku-ku",
               "postalCode": "160-0022",
               "__typename": "PostalAddress",
-              "stateName": "Tokyo",
+              "stateName": "东京都",
               "stateCode": null
             },
             "__typename": "RgdsStore"
@@ -2222,7 +2222,7 @@
               "city": "Chuo-ku",
               "postalCode": "104-0061",
               "__typename": "PostalAddress",
-              "stateName": "Tokyo",
+              "stateName": "东京都",
               "stateCode": null
             },
             "__typename": "RgdsStore"
@@ -2231,7 +2231,7 @@
       },
       {
         "__typename": "RgdsState",
-        "name": "Aichi",
+        "name": "爱知县",
         "store": [
           {
             "id": "R005",
@@ -2244,7 +2244,7 @@
               "city": "Nagoya-shi",
               "postalCode": "460-0008",
               "__typename": "PostalAddress",
-              "stateName": "Aichi",
+              "stateName": "爱知县",
               "stateCode": null
             },
             "__typename": "RgdsStore"
@@ -2253,7 +2253,7 @@
       },
       {
         "__typename": "RgdsState",
-        "name": "Kanagawa",
+        "name": "神奈川县",
         "store": [
           {
             "id": "R710",
@@ -2266,7 +2266,7 @@
               "city": "Kawasaki-shi",
               "postalCode": "212-8576",
               "__typename": "PostalAddress",
-              "stateName": "Kanagawa",
+              "stateName": "神奈川县",
               "stateCode": null
             },
             "__typename": "RgdsStore"
@@ -2275,7 +2275,7 @@
       },
       {
         "__typename": "RgdsState",
-        "name": "Kyoto",
+        "name": "京都府",
         "store": [
           {
             "id": "R711",
@@ -2288,7 +2288,7 @@
               "city": "Kyoto-shi",
               "postalCode": "600-8006",
               "__typename": "PostalAddress",
-              "stateName": "Kyoto",
+              "stateName": "京都府",
               "stateCode": null
             },
             "__typename": "RgdsStore"
@@ -2297,7 +2297,7 @@
       },
       {
         "__typename": "RgdsState",
-        "name": "Fukuoka",
+        "name": "福冈县",
         "store": [
           {
             "id": "R048",
@@ -2310,7 +2310,7 @@
               "city": "Fukuoka-shi",
               "postalCode": "810-0001",
               "__typename": "PostalAddress",
-              "stateName": "Fukuoka",
+              "stateName": "福冈县",
               "stateCode": null
             },
             "__typename": "RgdsStore"
@@ -2319,7 +2319,7 @@
       },
       {
         "__typename": "RgdsState",
-        "name": "Osaka",
+        "name": "大阪府",
         "store": [
           {
             "id": "R768",
@@ -2332,7 +2332,7 @@
               "city": "Osaka-shi",
               "postalCode": "530-0011",
               "__typename": "PostalAddress",
-              "stateName": "Osaka",
+              "stateName": "大阪府",
               "stateCode": null
             },
             "__typename": "RgdsStore"
@@ -2348,7 +2348,7 @@
               "city": "Osaka-shi",
               "postalCode": "542-0086",
               "__typename": "PostalAddress",
-              "stateName": "Osaka",
+              "stateName": "大阪府",
               "stateCode": null
             },
             "__typename": "RgdsStore"
@@ -2361,7 +2361,7 @@
     "states": [
       {
         "__typename": "RgdsState",
-        "name": "Tokyo",
+        "name": "东京都",
         "store": [
           {
             "id": "R718",
@@ -2374,7 +2374,7 @@
               "city": "Chiyoda-ku",
               "postalCode": "100-0005",
               "__typename": "PostalAddress",
-              "stateName": "Tokyo",
+              "stateName": "东京都",
               "stateCode": null
             },
             "__typename": "RgdsStore"
@@ -2390,7 +2390,7 @@
               "city": "Shibuya-ku",
               "postalCode": "150-0041",
               "__typename": "PostalAddress",
-              "stateName": "Tokyo",
+              "stateName": "东京都",
               "stateCode": null
             },
             "__typename": "RgdsStore"
@@ -2406,7 +2406,7 @@
               "city": "Shibuya-ku",
               "postalCode": "150-0001",
               "__typename": "PostalAddress",
-              "stateName": "Tokyo",
+              "stateName": "东京都",
               "stateCode": null
             },
             "__typename": "RgdsStore"
@@ -2422,7 +2422,7 @@
               "city": "Shinjuku-ku",
               "postalCode": "160-0022",
               "__typename": "PostalAddress",
-              "stateName": "Tokyo",
+              "stateName": "东京都",
               "stateCode": null
             },
             "__typename": "RgdsStore"
@@ -2438,7 +2438,7 @@
               "city": "Chuo-ku",
               "postalCode": "104-0061",
               "__typename": "PostalAddress",
-              "stateName": "Tokyo",
+              "stateName": "东京都",
               "stateCode": null
             },
             "__typename": "RgdsStore"
@@ -2447,7 +2447,7 @@
       },
       {
         "__typename": "RgdsState",
-        "name": "Aichi",
+        "name": "爱知县",
         "store": [
           {
             "id": "R005",
@@ -2460,7 +2460,7 @@
               "city": "Nagoya-shi",
               "postalCode": "460-0008",
               "__typename": "PostalAddress",
-              "stateName": "Aichi",
+              "stateName": "爱知县",
               "stateCode": null
             },
             "__typename": "RgdsStore"
@@ -2469,7 +2469,7 @@
       },
       {
         "__typename": "RgdsState",
-        "name": "Kanagawa",
+        "name": "神奈川县",
         "store": [
           {
             "id": "R710",
@@ -2482,7 +2482,7 @@
               "city": "Kawasaki-shi",
               "postalCode": "212-8576",
               "__typename": "PostalAddress",
-              "stateName": "Kanagawa",
+              "stateName": "神奈川县",
               "stateCode": null
             },
             "__typename": "RgdsStore"
@@ -2491,7 +2491,7 @@
       },
       {
         "__typename": "RgdsState",
-        "name": "Kyoto",
+        "name": "京都府",
         "store": [
           {
             "id": "R711",
@@ -2504,7 +2504,7 @@
               "city": "Kyoto-shi",
               "postalCode": "600-8006",
               "__typename": "PostalAddress",
-              "stateName": "Kyoto",
+              "stateName": "京都府",
               "stateCode": null
             },
             "__typename": "RgdsStore"
@@ -2513,7 +2513,7 @@
       },
       {
         "__typename": "RgdsState",
-        "name": "Fukuoka",
+        "name": "福冈县",
         "store": [
           {
             "id": "R048",
@@ -2526,7 +2526,7 @@
               "city": "Fukuoka-shi",
               "postalCode": "810-0001",
               "__typename": "PostalAddress",
-              "stateName": "Fukuoka",
+              "stateName": "福冈县",
               "stateCode": null
             },
             "__typename": "RgdsStore"
@@ -2535,7 +2535,7 @@
       },
       {
         "__typename": "RgdsState",
-        "name": "Osaka",
+        "name": "大阪府",
         "store": [
           {
             "id": "R768",
@@ -2548,7 +2548,7 @@
               "city": "Osaka-shi",
               "postalCode": "530-0011",
               "__typename": "PostalAddress",
-              "stateName": "Osaka",
+              "stateName": "大阪府",
               "stateCode": null
             },
             "__typename": "RgdsStore"
@@ -2564,7 +2564,7 @@
               "city": "Osaka-shi",
               "postalCode": "542-0086",
               "__typename": "PostalAddress",
-              "stateName": "Osaka",
+              "stateName": "大阪府",
               "stateCode": null
             },
             "__typename": "RgdsStore"


### PR DESCRIPTION
## Summary
- translate Japanese area and state names to Chinese in the store configuration
- update the macOS packaging workflow to use native fyne packaging and keep ad-hoc signing

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68df97cd79e08331a1113c19176aaf3c